### PR TITLE
Fix introduced typos & redundant code

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 </p>
 <h1 align="center">Pods Gravity Forms Add-On</h1>
 <p align="center">
-Integrate with [Gravity Forms](http://www.gravityforms.com/) to create a Pod from a form submission.
+Integrate with <a href="http://www.gravityforms.com/">Gravity Forms</a> to create a Pod from a form submission.
 </p>
 <p>
 <br />
-_Please Note: This plugin is currently in alpha development._
+<em>Please Note: This plugin is currently in alpha development.</em>
 </p>
 
 ## Requirements

--- a/includes/Pods_GF.php
+++ b/includes/Pods_GF.php
@@ -1033,10 +1033,10 @@ class Pods_GF {
 
 			wp_enqueue_script( 'pods-gf' );
 
-			$button_input .= ' <input type="button" class="button gform_button pods-gf-save-for-later" value="' . esc_attr__( 'Save for Later', 'pods-gf-ui' ) . '" />';
+			$button_input .= ' <input type="button" class="button gform_button pods-gf-save-for-later" value="' . esc_attr__( 'Save for Later', 'pods-gravity-forms' ) . '" />';
 
 			if ( 1 == pods_v( 'pods_gf_save_for_later_loaded', 'post' ) ) {
-				$button_input .= ' <input type="button" class="button gform_button pods-gf-save-for-later-reset" value="' . esc_attr__( 'Reset Saved Form', 'pods-gf-ui' ) . '" />';
+				$button_input .= ' <input type="button" class="button gform_button pods-gf-save-for-later-reset" value="' . esc_attr__( 'Reset Saved Form', 'pods-gravity-forms' ) . '" />';
 			}
 
 			if ( !empty( $save_for_later[ 'redirect' ] ) ) {
@@ -2962,7 +2962,7 @@ class Pods_GF {
 		self::$actioned[ $form[ 'id' ] ][] = __FUNCTION__;
 
 		if ( !empty( $this->gf_validation_message ) ) {
-			if ( false === strpos( $validation_message, __( "There was a problem with your submission.", "gravityforms" ) . " " . __( "Errors have been highlighted below.", "gravityforms" ) ) ) {
+			if ( false === strpos( $validation_message, __( 'There was a problem with your submission.', 'pods-gravity-forms' ) . " " . __( 'Errors have been highlighted below.', 'pods-gravity-forms' ) ) ) {
 				$validation_message .= "\n" . '<div class="validation_error">' . $this->gf_validation_message . '</div>';
 			}
 			else {

--- a/includes/Pods_GF_UI.php
+++ b/includes/Pods_GF_UI.php
@@ -780,7 +780,7 @@ class Pods_GF_UI {
 					$link = $obj->action_links[ 'manage' ];
 				}
 		?>
-			<a href="<?php echo $link; ?>" class="add-new-h2">&laquo; <?php echo sprintf( __( 'Back to %s', 'pods' ), $obj->heading[ 'manage' ] ); ?></a>
+			<a href="<?php echo $link; ?>" class="add-new-h2">&laquo; <?php echo sprintf( __( 'Back to %s', 'pods-gravity-forms' ), $obj->heading[ 'manage' ] ); ?></a>
 		<?php
 			}
 		?>
@@ -827,7 +827,7 @@ class Pods_GF_UI {
 		}
 
 		if ( empty( $obj->row ) ) {
-			$obj->message( sprintf( __( '%s not found.', 'pods' ), $obj->item ) );
+			$obj->message( sprintf( __( '%s not found.', 'pods-gravity-forms' ), $obj->item ) );
 
 			return;
 		}
@@ -845,7 +845,7 @@ class Pods_GF_UI {
 					$link = $obj->action_links[ 'manage' ];
 				}
 		?>
-			<a href="<?php echo $link; ?>" class="add-new-h2">&laquo; <?php echo sprintf( __( 'Back to %s', 'pods' ), $obj->heading[ 'manage' ] ); ?></a>
+			<a href="<?php echo $link; ?>" class="add-new-h2">&laquo; <?php echo sprintf( __( 'Back to %s', 'pods-gravity-forms' ), $obj->heading[ 'manage' ] ); ?></a>
 		<?php
 			}
 		?>
@@ -885,7 +885,7 @@ class Pods_GF_UI {
 		}
 
 		if ( empty( $obj->row ) ) {
-			$obj->message( sprintf( __( '%s not found.', 'pods' ), $obj->item ) );
+			$obj->message( sprintf( __( '%s not found.', 'pods-gravity-forms' ), $obj->item ) );
 
 			return;
 		}
@@ -903,7 +903,7 @@ class Pods_GF_UI {
 					$link = $obj->action_links[ 'manage' ];
 				}
 		?>
-			<a href="<?php echo $link; ?>" class="add-new-h2">&laquo; <?php echo sprintf( __( 'Back to %s', 'pods' ), $obj->heading[ 'manage' ] ); ?></a>
+			<a href="<?php echo $link; ?>" class="add-new-h2">&laquo; <?php echo sprintf( __( 'Back to %s', 'pods-gravity-forms' ), $obj->heading[ 'manage' ] ); ?></a>
 		<?php
 			}
 		?>
@@ -953,7 +953,7 @@ class Pods_GF_UI {
 			do_action( 'pods_gf_ui' . __FUNCTION__, $this->id, $this->pod, $obj, $this );
 		}
 
-		$obj->message( sprintf( __( '%s deleted successfully.', 'pods' ), $obj->item ) );
+		$obj->message( sprintf( __( '%s deleted successfully.', 'pods-gravity-forms' ), $obj->item ) );
 
 		return null;
 

--- a/pods-gravity-forms.php
+++ b/pods-gravity-forms.php
@@ -3,13 +3,13 @@
 Plugin Name: Pods Gravity Forms Add-On
 Plugin URI: http://pods.io/
 Description: Integration with Gravity Forms (http://www.gravityforms.com/); Provides a UI for mapping a Form's submissions into a Pod
-Version: 1.0 Alpha 5
+Version: 1.0 Alpha 6
 Author: Pods Framework Team
 Author URI: http://pods.io/about/
 Text Domain: pods-gravity-forms
 Domain Path: /languages/
 
-Copyright 2013  Pods Foundation, Inc  (email : contact@podsfoundation.org)
+Copyright 2013-2014  Pods Foundation, Inc  (email : contact@podsfoundation.org)
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -30,24 +30,24 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  * @package Pods\Gravity Forms
  */
 
-define( 'PODS_GF_VERSION', '1.0-a-5' );
+define( 'PODS_GF_VERSION', '1.0-a-6' );
 define( 'PODS_GF_FILE', __FILE__ );
 define( 'PODS_GF_DIR', plugin_dir_path( PODS_GF_FILE ) );
 define( 'PODS_GF_URL', plugin_dir_url( PODS_GF_FILE ) );
 define( 'PODS_GF_ADDON_FILE', basename( PODS_GF_DIR ) . '/' . basename( PODS_GF_FILE ) );
 
 /**
- * @global Pods_GF_UI $GLOBALS['pods_gf_ui']
- * @name $pods_gf_ui
+ * @global Pods_GF_UI $GLOBALS ['pods_gf_ui']
+ * @name              $pods_gf_ui
  */
 global $pods_gf_ui, $pods_gf_ui_loaded;
 
 /**
  * Include the Pods GF Add-On
  */
-function pods_gf_init() {
+function pods_gf_init () {
 
-	if ( !function_exists( 'pods' ) || !class_exists( 'GFCommon' ) ) {
+	if ( ! function_exists( 'pods' ) || ! class_exists( 'GFCommon' ) ) {
 		return false;
 	}
 
@@ -55,7 +55,7 @@ function pods_gf_init() {
 	require_once( PODS_GF_DIR . 'includes/functions.php' );
 
 	// Include GF Feed Addon code
-	if ( !class_exists( 'GFFeedAddOn' ) ) {
+	if ( ! class_exists( 'GFFeedAddOn' ) ) {
 		GFForms::include_feed_addon_framework();
 	}
 
@@ -74,37 +74,23 @@ function pods_gf_init() {
 	}
 
 }
+
 add_action( 'init', 'pods_gf_init' );
 
 // Warning: Gravity Forms Duplicate Prevention plugin's JS *will* break secondary submits!
 // So we need to disable it now
 add_filter( 'gform_duplicate_prevention_load_script', '__return_false' );
 
-// Include GF Feed Addon code
-if ( class_exists( 'GFForms' ) && !class_exists( 'GFFeedAddOn' ) ) {
-	GFForms::include_feed_addon_framework();
-}
-
-add_action( 'plugins_loaded', 'pods_gf_inclue' );
-function pods_gf_inclue() {
- 	// Include GF Add-On
-	if ( class_exists( 'GFForms' ) && defined( 'PODS_VERSION' ) ) {
-		require_once( PODS_GF_DIR . 'includes/Pods_GF_Addon.php' );
-	}
-}
-
-
 /**
  * Admin nag if Pods or GF isn't activated.
  */
 add_action( 'plugins_loaded', 'pods_gf_admin_nag' );
-function pods_gf_admin_nag() {
-	if ( is_admin() && ( !class_exists( 'GFForms' ) || !defined( 'PODS_VERSION' ) ) ) {
+
+function pods_gf_admin_nag () {
+	if ( is_admin() && ( ! class_exists( 'GFForms' ) || ! defined( 'PODS_VERSION' ) ) ) {
 		echo sprintf( '<div id="message" class="error"><p>%s</p></div>',
-			sprintf(
-				__( '%1$s requires that the Pods and Gravity Forms core plugins be installed and activated.', 'pods-gf' ),
-				'Pods Gravity Forms' )
+						  __( 'Pods Gravity Forms requires that the Pods and Gravity Forms core plugins be installed and activated.', 'pods-gravity-forms' )
 		);
 	}
-	
+
 }


### PR DESCRIPTION
There were typos introduced in the admin nag added in the last commit. And the check for Pods and Gravity Forms as well as adding the Add-On Framework is already handled in pods_gf_init.
- Fix incorrect text domains for internationalized strings
- Increment version number so people know to download new version
