### PR TITLE
Add support for forms embedded on the dashboard

### DIFF
--- a/includes/Pods_GF_Addon.php
+++ b/includes/Pods_GF_Addon.php
@@ -418,12 +418,14 @@ class Pods_GF_Addon extends GFFeedAddOn {
 
 	}
 
-	public function init_frontend() {
+	public function init() {
 
-		parent::init_frontend();
+		parent::init();
 
-		add_filter( 'gform_pre_render', array( $this, '_gf_pre_render' ) );
-		add_action( 'gform_pre_process', array( $this, '_gf_pre_process' ) );
+		if ( $this->is_gravityforms_supported() ) {
+			add_filter( 'gform_pre_render', array( $this, '_gf_pre_render' ) );
+			add_action( 'gform_pre_process', array( $this, '_gf_pre_process' ) );
+		}
 
 	}
 


### PR DESCRIPTION
Moving the gform_pre_render and gform_pre_process hooks from `Pods_GF_Addon::init_frontend()` to `Pods_GF_Addon::init()` to resolve issue #64. 