### PR TITLE
Use get_input_type() when checking File Upload and Post Image fields

### DIFF
--- a/includes/Pods_GF.php
+++ b/includes/Pods_GF.php
@@ -1803,7 +1803,7 @@ class Pods_GF {
 			$value = apply_filters( 'pods_gf_to_pods_value', $value, $field, $field_options, $form, $gf_field, $data, $options );
 
 			// If a file is not set, check if we are editing an item.
-			if ( null === $value && in_array( $gf_field->type, array( 'fileupload', 'post_image' ), true ) ) {
+			if ( null === $value && in_array( $gf_field->get_input_type(), array( 'fileupload', 'post_image' ), true ) ) {
 				// If we are editing an item, don't attempt to save.
 				if ( is_object( $pod ) && $pod->id ) {
 					continue;
@@ -3637,7 +3637,7 @@ class Pods_GF {
 			$value = maybe_unserialize( $value );
 		}
 
-		if ( in_array( $gf_field->type, array( 'post_category', 'post_title', 'post_content', 'post_excerpt', 'post_tags', 'post_custom_field', 'post_image' ) ) ) {
+		if ( in_array( $gf_field->get_input_type(), array( 'post_category', 'post_title', 'post_content', 'post_excerpt', 'post_tags', 'post_custom_field', 'post_image' ) ) ) {
 			// Block new post being created in GF
 			add_filter( 'gform_disable_post_creation_' . $form['id'], '__return_true' );
 		}
@@ -3884,7 +3884,7 @@ class Pods_GF {
 			} else {
 				$value = null;
 			}
-		} elseif ( $handle_files && in_array( $gf_field->type, array( 'fileupload', 'post_image' ), true ) ) {
+		} elseif ( $handle_files && in_array( $gf_field->get_input_type(), array( 'fileupload', 'post_image' ), true ) ) {
 			$value = null;
 
 			$attachments = array();
@@ -4212,7 +4212,7 @@ class Pods_GF {
 				$gf_value = self::get_gf_field_value( $value, $gf_params );
 
 				// If a file is not set, check if we are editing an item.
-				if ( null === $gf_value && in_array( $field->type, array( 'fileupload', 'post_image' ), true ) ) {
+				if ( null === $gf_value && in_array( $field->get_input_type(), array( 'fileupload', 'post_image' ), true ) ) {
 					// If we are editing an item, return normal result, don't attempt to save.
 					if ( is_object( $this->pod ) && $this->pod->id ) {
 						return $validation_result;


### PR DESCRIPTION
Gravity Forms is highly extensible and this lets developers build new fields based on the existing fields. When developers do this it requires a unique string to be set for `$gf_field->type`, but in most cases you can maintain the original field's functionality by setting the `$gf_field->inputType` back to the original type. This specific feature is how Gravity Forms builds add-ons like Polls and Surveys – which extend the radio and checkbox fields – and how the Custom Field post field works. 

This PR switches to `get_input_type()` when processing file upload and post image fields. This change will allow [Image Hopper](https://imagehopper.tech/) (any other fields that extend these two fields) to be correctly processed by Pods on form submission.

This change should likely be done for all references to `$gf_field->type`. However, to make this PR easy to test/verify and to prevent any unexpected issues with other fields, I've limited it only to those that reference `fileupload` and `post_image` types. I've a bunch of experience testing and implementing this specific change for Gravity Forms, and this modification poses a very low risk of causing an issue. I won't say no risk, because nothing is 100% certain in an ecosystem like WordPress, but I haven't discovered any breaking changes caused by making this switch elsewhere.